### PR TITLE
Add a "riscv*-unknown-none" toolchain

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -34,6 +34,7 @@ export PATH AWK SED
 MULTILIB_FLAGS := @multilib_flags@
 MULTILIB_NAMES := @multilib_names@
 GCC_CHECKING_FLAGS := @gcc_checking@
+NEWLIB_SYSTEM := @newlib_system@
 
 XLEN := $(shell echo $(WITH_ARCH) | tr A-Z a-z | sed 's/.*rv\([0-9]*\).*/\1/')
 ifneq ($(XLEN),32)
@@ -42,7 +43,7 @@ endif
 
 make_tuple = riscv$(1)-unknown-$(2)
 LINUX_TUPLE  ?= $(call make_tuple,$(XLEN),linux-gnu)
-NEWLIB_TUPLE ?= $(call make_tuple,$(XLEN),elf)
+NEWLIB_TUPLE ?= $(call make_tuple,$(XLEN),$(NEWLIB_SYSTEM))
 
 CFLAGS_FOR_TARGET := $(CFLAGS_FOR_TARGET_EXTRA) @cmodel@
 ASFLAGS_FOR_TARGET := $(ASFLAGS_FOR_TARGET_EXTRA) @cmodel@

--- a/configure
+++ b/configure
@@ -593,6 +593,8 @@ multilib_names
 multilib_flags
 WITH_ABI
 WITH_ARCH
+newlib_system
+enable_libgloss
 default_target
 FETCHER
 FTP
@@ -654,6 +656,7 @@ ac_subst_files=''
 ac_user_opts='
 enable_option_checking
 enable_linux
+enable_libnosys
 enable_atomic
 with_arch
 with_abi
@@ -1294,6 +1297,7 @@ Optional Features:
   --enable-FEATURE[=ARG]  include FEATURE [ARG=yes]
   --enable-linux          set linux as the default make target
                           [--disable-linux]
+  --enable-libnosys       build a toolchain without system call support
   --disable-atomic        disable use of atomic memory instructions in glibc
                           [--enable-atomic]
   --enable-multilib       build both RV32 and RV64 runtime libraries
@@ -3224,6 +3228,31 @@ if test "x$enable_linux" != xno; then :
 
 else
   default_target=newlib
+
+fi
+
+# Check whether --enable-libnosys was given.
+if test "${enable_libnosys+set}" = set; then :
+  enableval=$enable_libnosys;
+else
+  enable_libnosys=no
+
+fi
+
+
+if test "x$enable_libnosys" != xno; then :
+  enable_libgloss=--enable-libgloss
+
+else
+  enable_libgloss=--disable-libgloss
+
+fi
+
+if test "x$enable_libnosys" != xno; then :
+  newlib_system=none
+
+else
+  newlib_system=elf
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -50,6 +50,17 @@ AS_IF([test "x$enable_linux" != xno],
 	[AC_SUBST(default_target, linux)],
 	[AC_SUBST(default_target, newlib)])
 
+AC_ARG_ENABLE(libnosys,
+	[AS_HELP_STRING([--enable-libnosys],
+		[build a toolchain without system call support])],
+	[],
+	[enable_libnosys=no]
+	)
+
+AS_IF([test "x$enable_libnosys" != xno],
+	[AC_SUBST(newlib_system, none)],
+	[AC_SUBST(newlib_system, elf)])
+
 AC_ARG_ENABLE(atomic,
 	[AS_HELP_STRING([--disable-atomic],
 		[disable use of atomic memory instructions in glibc @<:@--enable-atomic@:>@])],


### PR DESCRIPTION
This links against "libnosys" instead of "libgloss".  As a result, there
should be no "ecall" instructions in any program unless you explicitly
put them there yourself.  "libnosys" provides system call routines that
error out at runtime instead of calling system calls, so nominally this
toolchain is still a legal